### PR TITLE
Di 1992

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,12 +1,12 @@
 {
   "name": "eggd_mosdepth",
-  "title": "eggd_mosdepth_v1.1.0",
-  "version": "1.1.0",
-  "whatsNew": "* v1.1.0 Uses samtools v1.18 as an asset and mosdepth docker as an input, updated app name and runSpec.",
+  "title": "eggd_mosdepth_v1.2.0",
+  "version": "1.2.0",
+  "whatsNew": "* v1.2.0 updated to use CRAM",
   "summary": "Runs mosdepth to perform coverage analysis",
   "dxapi": "1.0.0",
   "properties": {
-  "githubRelease": "v1.1.0"
+  "githubRelease": "v1.2.0"
   },
   "inputSpec": [
     {
@@ -29,9 +29,29 @@
       "class": "file",
       "optional": false,
       "patterns": [
-        "*.bam$"
+        "*.bam$", "*.cram$"
       ],
       "help": "BAM file to generate bp coverage on"
+    },
+    {
+      "name": "reference_fasta",
+      "label": "fasta file",
+      "class": "file",
+      "optional": true,
+      "patterns": [
+        "*.fa.gz"
+      ],
+      "help": "reference file to align CRAM file to"
+    },
+    {
+      "name": "reference_fasta_index",
+      "label": "fasta index file",
+      "class": "file",
+      "optional": true,
+      "patterns": [
+        "*.fa.fai"
+      ],
+      "help": "Index reference file to align CRAM file to"
     },
     {
       "name": "index",
@@ -39,7 +59,7 @@
       "class": "file",
       "optional": false,
       "patterns": [
-        "*.bai$"
+        "*.bai$", "*crai$"
       ],
       "help": "Index of BAM"
     },

--- a/dxapp.json
+++ b/dxapp.json
@@ -2,7 +2,7 @@
   "name": "eggd_mosdepth",
   "title": "eggd_mosdepth_v1.2.0",
   "version": "1.2.0",
-  "whatsNew": "* v1.2.0 updated to use CRAM",
+  "whatsNew": "* v1.1.0 Uses samtools v1.18 as an asset and mosdepth docker as an input, updated app name and runSpec.* v1.2.0 updated to use CRAM",
   "summary": "Runs mosdepth to perform coverage analysis",
   "dxapi": "1.0.0",
   "properties": {
@@ -24,14 +24,14 @@
       "help": "List of comma seperated labels for bins if using --quantize, number of labels must match number of bins. If none are given the defaults from the readme are passed."
     },
     {
-      "name": "bam",
-      "label": "BAM file",
+      "name": "alignment_file",
+      "label": "BAM or CRAM file",
       "class": "file",
       "optional": false,
       "patterns": [
         "*.bam$", "*.cram$"
       ],
-      "help": "BAM file to generate bp coverage on"
+      "help": "BAM or CRAM alignment file to generate bp coverage on"
     },
     {
       "name": "reference_fasta",
@@ -54,14 +54,14 @@
       "help": "Index reference file to align CRAM file to"
     },
     {
-      "name": "index",
+      "name": "alignment_index",
       "label": "Index file",
       "class": "file",
       "optional": false,
       "patterns": [
         "*.bai$", "*crai$"
       ],
-      "help": "Index of BAM"
+      "help": "Index of BAM or CRAM alignment file"
     },
     {
       "name": "bed",

--- a/src/eggd_mosdepth.sh
+++ b/src/eggd_mosdepth.sh
@@ -16,8 +16,12 @@ main() {
     echo $ref >> out/mosdepth_output/$alignment_file_prefix.reference_build.txt
 
     # set up reference fasta
-    gunzip input/${reference_fasta_prefix}.fa.gz
-    fasta="--fasta /data/input/$reference_fasta_prefix.fa"
+    if [[ -n "${reference_fasta_prefix}" ]]; then
+      gunzip "input/${reference_fasta_prefix}.fa.gz"
+      fasta="--fasta /data/input/${reference_fasta_prefix}.fa"
+    else
+      fasta=""
+    fi
 
     # check if set, if not set to empty string
     if [[ -z $optional_arguments ]]; then
@@ -49,10 +53,10 @@ main() {
     mosdepth_id=$(docker images --format="{{.Repository}} {{.ID}}" | grep "^quay.io" | cut -d' ' -f2) 
 
     if [[ $optional_arguments =~ "--quantize" ]]; then
-        
+
         # if --quantize option given
         # set bam path variable to pass
-        input_alignment_file=$(find input/$alignment_file_prefix.*am)
+        input_alignment_file=$(find input -maxdepth 1 -type f -name "${alignment_file_prefix}.*am" | head -n 1)
 
         if [[ $quantize_labels ]]; then
           # optional labels passed
@@ -90,7 +94,8 @@ main() {
     # not using quantize option, run mosdepth normally with container
 
     # set paths to inputs for Docker
-    input_alignment_file=$(find input/$alignment_file.*am)
+    input_alignment_file=$(find input -maxdepth 1 -type f -name "${alignment_file_prefix}.*am" | head -n 1)
+
     echo $input_alignment_file
 
     sudo docker run -v `pwd`:/data -w "/data/out/mosdepth_output" $mosdepth_id mosdepth $optional_arguments $fasta $alignment_file_prefix /data/$input_alignment_file

--- a/src/eggd_mosdepth.sh
+++ b/src/eggd_mosdepth.sh
@@ -81,17 +81,20 @@ main() {
         fi
     elif [[ $optional_arguments =~ "--fasta" ]]; then
     echo "Using option argument --fasta, this is necessary when using CRAM files"
-    optional_arguments="--flag 1796 --mapq 20"
+    # remove --fasta from optional arguments to include with fasta
+    optional_arguments=${optional_arguments//"--fasta"/}
     echo $optional_arguments
+
+    # unzip reference 
     gunzip input/${reference_fasta_prefix}.fa.gz
-    ls input/
+    # set paths to inputs for Docker
     cram_file="/data/input/$bam_prefix.cram"
+    fasta_file="/data/input/$reference_fasta_prefix.fa"
 
     sudo docker run -v `pwd`:/data \
           --env optional_arguments="$optional_arguments" \
           --env bam_prefix="$bam_prefix" --env bam_file="$cram_file" \
-          --env REF_PATH="/data/input/GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fa" \
-          --env fasta="--fasta /data/input/GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fa" \
+          --env fasta="--fasta $fasta_file" \
           -w "/data/out/mosdepth_output" \
           $mosdepth_id /bin/bash -c \
           'mosdepth $optional_arguments $fasta $bam_prefix $bam_file'


### PR DESCRIPTION
- Update Mosdepth to accept CRAM files
- Add reference genome input to eggd_mosdepth

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_mosdepth/13)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for CRAM files as input, alongside BAM files.
  * Introduced optional inputs for reference FASTA and its index to support CRAM alignment.

* **Bug Fixes**
  * Improved handling of input file paths and ensured proper use of reference FASTA files within the analysis process.

* **Chores**
  * Updated version and metadata to reflect the new release and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->